### PR TITLE
update base-library to latest version

### DIFF
--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -135,7 +135,7 @@ NAN_METHOD(Init) {
   int err = ws2811_init(&ledstring);
 
   if(err) {
-      return NanThrowError("init(): initialization failed. sorry – no idea why.", err);
+      return NanThrowError("init(): initialization failed. sorry – no idea why.");
   }
 
   NanReturnValue(NanUndefined());


### PR DESCRIPTION
integrate latest changes from beyondscreen/rpi_ws281x:

 - fix problem with kernels that do not support creating mbox-devices (using /dev/vcio from here on)
 - fix compiler warnings

fixes issues #33 and #35 