### PR TITLE
Always return stubs instead of calling process.exit().

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -1,21 +1,20 @@
 var EventEmitter = require('events').EventEmitter;
 
-if(process.getuid() !== 0) {
-    process.stderr.write(
-        '[rpi-ws281x-native] ERROR: this module requires being run with ' +
-        'root-privileges. Please use the command\n\n' +
-        '    sudo ' + process.argv.join(' ') + '\n\n' +
-        'to run it again.\n'
-    );
 
-    process.exit(1);
-}
 
 function getNativeBindings() {
+    var convenienceMessage = 'For convenience, implementation stubs are provided.';
+
+    if (process.getuid() !== 0) {
+        var message = '[rpi-ws281x-native] This module requires being run with ' +
+        'root-privileges. ' + convenienceMessage;
+        console.warn(message);
+    }
+
     // the native module might even be harmful (or won't work in the best case)
     // in the wrong environment, so we make sure that at least everything we can
     // test for matches the raspberry-pi before loading the native-module
-    if(process.arch === 'arm' || process.platform === 'linux') {
+    else if (process.arch === 'arm' || process.platform === 'linux') {
 
         // will only work on RPi1 (Broadcom BCM2708) and RPi2 (BCM2709) and
         // this is the best check i could come up with to see which one we are
@@ -38,11 +37,10 @@ function getNativeBindings() {
                 return require('./binding/rpi_ws281x.node');
 
             default:
-                process.stderr.write(
-                    '[rpi-ws281x-native] it looks like you are not running ' +
-                    'on a raspberry pi so there will be no functionality ' +
-                    'exposed by this module. For convenience, ' +
-                    'implementation stubs are provided.\n'
+                console.warn(
+                    '[rpi-ws281x-native] It looks like you are not running ' +
+                    'on a raspberry pi. This module doesn\'t work ' +
+                    'on anything else. ' + convenienceMessage
                 );
         }
     }

--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -3,54 +3,61 @@ var EventEmitter = require('events').EventEmitter;
 
 
 function getNativeBindings() {
-    var convenienceMessage = 'For convenience, implementation stubs are provided.';
-
-    if (process.getuid() !== 0) {
-        var message = '[rpi-ws281x-native] This module requires being run with ' +
-        'root-privileges. ' + convenienceMessage;
-        console.warn(message);
-    }
-
-    // the native module might even be harmful (or won't work in the best case)
-    // in the wrong environment, so we make sure that at least everything we can
-    // test for matches the raspberry-pi before loading the native-module
-    else if (process.arch === 'arm' || process.platform === 'linux') {
-
-        // will only work on RPi1 (Broadcom BCM2708) and RPi2 (BCM2709) and
-        // this is the best check i could come up with to see which one we are
-        // dealing with.
-        var raspberryVersion = (function() {
-            var cpuInfo = require('fs').readFileSync('/proc/cpuinfo').toString(),
-                socFamily = cpuInfo.match(/hardware\s*:\s*(bcm270[89])/i);
-
-            if(!socFamily) { return 0; }
-
-            switch(socFamily[1].toLowerCase()) {
-                case 'bcm2708': return 1;
-                case 'bcm2709': return 2;
-                default: return 0;
-            }
-        } ());
-
-        switch(raspberryVersion) {
-            case 1: case 2:
-                return require('./binding/rpi_ws281x.node');
-
-            default:
-                console.warn(
-                    '[rpi-ws281x-native] It looks like you are not running ' +
-                    'on a raspberry pi. This module doesn\'t work ' +
-                    'on anything else. ' + convenienceMessage
-                );
-        }
-    }
-
-    return {
+    var stub = {
         init: function() {},
         render: function() {},
         setBrightness: function() {},
         reset: function() {}
     };
+
+    if (process.getuid() !== 0) {
+        console.warn('[rpi-ws281x-native] This module requires being run ' +
+                'with root-privileges. A non-functional stub of the ' +
+                'interface will be returned.');
+
+        return stub;
+    }
+
+    // the native module might even be harmful (or won't work in the best case)
+    // in the wrong environment, so we make sure that at least everything we can
+    // test for matches the raspberry-pi before loading the native-module
+    if (process.arch !== 'arm' && process.platform !== 'linux') {
+        console.warn('[rpi-ws281x-native] It looks like you are not ' +
+                'running on a raspberry pi. This module will not work ' +
+                'on other platforms. A non-functional stub of the ' +
+                'interface will be returned.');
+
+        return stub;
+    }
+
+    // determine rapsberry-pi version based on SoC-family. (note: a more
+    // detailed way would be to look at the revision-field from cpuinfo, see
+    // http://elinux.org/RPi_HardwareHistory)
+    var raspberryVersion = (function() {
+        var cpuInfo = require('fs').readFileSync('/proc/cpuinfo').toString(),
+            socFamily = cpuInfo.match(/hardware\s*:\s*(bcm270[89])/i);
+
+        if(!socFamily) { return 0; }
+
+        switch(socFamily[1].toLowerCase()) {
+            case 'bcm2708': return 1;
+            case 'bcm2709': return 2;
+            default: return 0;
+        }
+    } ());
+
+    if (raspberryVersion === 0) {
+        console.warn('[rpi-ws281x-native] Could not verify raspberry-pi ' +
+                'version. If this is wrong and you are running this on a ' +
+                'raspberry-pi, please file a bug-report at ' +
+                '  https://github.com/beyondscreen/node-rpi-ws281x-native/issues\n' +
+                'A non-functional stub of this modules interface will be ' +
+                'returned.');
+
+        return stub;
+    }
+
+    return require('./binding/rpi_ws281x.node');
 }
 
 var bindings = getNativeBindings();


### PR DESCRIPTION
We are not very friendly to consumers by calling process.exit().
Instead we now log a warning and return the stubs for convenience.

This closes #42.

I know I proposed throwing an error. Though when I was halfway that change I thought it made more sense to always return the stubs. Most of the time people aren't developing on a Pi so they need stubs anyway. I think this is the most consumer friendly solution.

If we do opt for throwing an error I think we should at least expose the sub methods for consumers to use.

To give you an idea, this is what I had to write in my application using this library:
```js
let ws281x;

// Detect if we can safely load ws281x.
// Need to be root.
if (process.getuid && process.getuid() === 0) {
  ws281x = require('rpi-ws281x-native');
} else {
  console.log('Returning mocked ws281x.');
  ws281x = {
    init: () => {},
    render: () => {},
    setBrightness: () => {},
    reset: () => {}
  };
}

module.exports = ws281x;
```

As you can see quite a lot of code here is copied from this lib.

ps. If we release this I think it should be `0.8.0` since we are not strictly speaking backwards compatible with this change.