### PR TITLE
Avoid using process.getuid() on Windows.

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -10,7 +10,7 @@ function getNativeBindings() {
         reset: function() {}
     };
 
-    if (process.getuid() !== 0) {
+    if (!process.getuid || process.getuid() !== 0) {
         console.warn('[rpi-ws281x-native] This module requires being run ' +
                 'with root-privileges. A non-functional stub of the ' +
                 'interface will be returned.');


### PR DESCRIPTION
We used this lib on a Windows machine for the first time and it crashed ^_^
This should fix it!