### PR TITLE
Add ws281x.isStub() to find out if stub mode is enabled

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -7,7 +7,8 @@ function getNativeBindings() {
         init: function() {},
         render: function() {},
         setBrightness: function() {},
-        reset: function() {}
+        reset: function() {},
+        isStub: true
     };
 
     if (!process.getuid || process.getuid() !== 0) {
@@ -195,6 +196,10 @@ ws281x.reset = function() {
     _outputBuffer = null;
 
     bindings.reset();
+};
+
+ws281x.isStub = function() {
+    return bindings.isStub === true;
 };
 
 module.exports = ws281x;


### PR DESCRIPTION
Allows to check if the library is in stub mode.

Cannot test it because of:

```
make: Entering directory '/tmp/node-rpi-ws281x-native/build'
make: *** No rule to make target 'Release/obj.target/rpi_libws2811/src/rpi_ws281x/ws2811.o', needed by 'Release/obj.target/rpi_libws2811.a'.  Stop.
make: Leaving directory '/tmp/node-rpi-ws281x-native/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at emitTwo (events.js:125:13)
gyp ERR! stack     at ChildProcess.emit (events.js:213:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:200:12)
gyp ERR! System Linux 4.4.34-v7+
gyp ERR! command "/usr/local/bin/node" "/usr/local/bin/node-gyp" "rebuild"
gyp ERR! cwd /tmp/node-rpi-ws281x-native
gyp ERR! node -v v8.6.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
```