### PR TITLE
removed depecation warning and errors for 'HasOwnProperty'

### DIFF
--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -97,23 +97,23 @@ void init(const Nan::FunctionCallbackInfo<v8::Value>& info) {
         symInvert = Nan::New<String>("invert").ToLocalChecked(),
         symBrightness = Nan::New<String>("brightness").ToLocalChecked();
 
-    if(config->HasOwnProperty(symFreq)) {
+    if(Nan::HasOwnProperty(config, symFreq).FromMaybe(false)) {
       ledstring.freq = config->Get(symFreq)->Uint32Value();
     }
 
-    if(config->HasOwnProperty(symDmaNum)) {
+    if(Nan::HasOwnProperty(config, symDmaNum).FromMaybe(false)) {
       ledstring.dmanum = config->Get(symDmaNum)->Int32Value();
     }
 
-    if(config->HasOwnProperty(symGpioPin)) {
+    if(Nan::HasOwnProperty(config, symGpioPin).FromMaybe(false)) {
       ledstring.channel[0].gpionum = config->Get(symGpioPin)->Int32Value();
     }
 
-    if(config->HasOwnProperty(symInvert)) {
+    if(Nan::HasOwnProperty(config, symInvert).FromMaybe(false)) {
       ledstring.channel[0].invert = config->Get(symInvert)->Int32Value();
     }
 
-    if(config->HasOwnProperty(symBrightness)) {
+    if(Nan::HasOwnProperty(config, symBrightness).FromMaybe(false)) {
       ledstring.channel[0].brightness = config->Get(symBrightness)->Int32Value();
     }
   }


### PR DESCRIPTION
With node version 8.9.4 some deprecation warnings occurred (with Hint of Use Maybe).
With node version 10.1.0 the same lines (at least for my installation) throw errors and the package could not be installed. 

little Changes made it possible to run without warnings and errors.

(Hope I made it right, never worked with bindings directly before)


Regards
Omegahorus

PS: I just recognized, I only testet compiling, not running so far.