### PR TITLE
Fix for "this.emit is not a function" in Node 10

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -130,7 +130,7 @@ var _outputBuffer = null;
  *                           intialization-options for the library
  *                           (PWM frequency, DMA channel, GPIO, Brightness)
  */
-ws281x.init = function(numLeds, options) {
+var init = function(numLeds, options) {
     _isInitialized = true;
     _outputBuffer = new Buffer(4 * numLeds);
 
@@ -144,7 +144,7 @@ ws281x.init = function(numLeds, options) {
  *
  * @param {Array.<Number>} mapping  the mapping, indexed by destination.
  */
-ws281x.setIndexMapping = function(mapping) {
+var setIndexMapping = function(mapping) {
     _indexMapping = mapping;
 };
 
@@ -156,12 +156,12 @@ ws281x.setIndexMapping = function(mapping) {
  *                            RGB-format (0xff0000 is red).
  * @return {Uint32Array} data as it was sent to the LED-strip
  */
-ws281x.render = function(data) {
+var render = function(data) {
     if(!_isInitialized) {
         throw new Error('render called before initialization.');
     }
 
-    this.emit('beforeRender', data);
+    ws281x.emit('beforeRender', data);
 
     if(_indexMapping) {
         data = remap(data, _indexMapping);
@@ -172,12 +172,12 @@ ws281x.render = function(data) {
     }
     bindings.render(_outputBuffer);
 
-    this.emit('render', data);
+    ws281x.emit('render', data);
 
     return data;
 };
 
-ws281x.setBrightness = function(brightness) {
+var setBrightness = function(brightness) {
     if(!_isInitialized) {
         throw new Error('setBrightness called before initialization.');
     }
@@ -191,15 +191,22 @@ ws281x.setBrightness = function(brightness) {
  * clears all LEDs, resets the PWM and DMA-parts and deallocates
  * all internal structures.
  */
-ws281x.reset = function() {
+var reset = function() {
     _isInitialized = false;
     _outputBuffer = null;
 
     bindings.reset();
 };
 
-ws281x.isStub = function() {
+var isStub = function() {
     return bindings.isStub === true;
 };
 
-module.exports = ws281x;
+module.exports = {
+    init,
+    reset,
+    isStub,
+    setBrightness,
+    setIndexMapping,
+    render
+};


### PR DESCRIPTION
After running my app with the latest version on Node 10, I had an error about "this.emit is not a function".
Linter showed that adding custom properties/functions on EventEmitter is a bad idea -> I broke out all functions which made the error go away.