### PR TITLE
Replace use of deprecated new Buffer() call with Buffer.alloc()

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -132,7 +132,7 @@ var _outputBuffer = null;
  */
 ws281x.init = function(numLeds, options) {
     _isInitialized = true;
-    _outputBuffer = new Buffer(4 * numLeds);
+    _outputBuffer = Buffer.alloc(4 * numLeds);
 
     bindings.init(numLeds, options);
 };


### PR DESCRIPTION
Hello guys,

just stopping by to fix a small problem described in #95.

This has been verified on the Raspberry Pi 3B+ with node `v10.15.3`. As per documentation, this should also be supported in older version of node, such as `v6`, see [here](https://nodejs.org/docs/latest-v6.x/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding).