### PR TITLE
switch from using NAN to NAPI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/rpi_ws281x"]
     path = src/rpi_ws281x
-    url = https://github.com/beyondscreen/rpi_ws281x.git
+    url = https://github.com/ckirmse/rpi_ws281x.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/rpi_ws281x"]
     path = src/rpi_ws281x
-    url = https://github.com/ckirmse/rpi_ws281x.git
+    url = https://github.com/jgarff/rpi_ws281x.git

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,8 @@
           'target_name': 'rpi_ws281x',
           'sources': ['./src/rpi-ws281x.cc'],
           'dependencies': ['rpi_libws2811'],
-          'include_dirs': ['<!(node -e "require(\'nan\')")']
+          'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
+          'defines': ['NAPI_DISABLE_CPP_EXCEPTIONS'],
         },
 
         {
@@ -18,8 +19,10 @@
             './src/rpi_ws281x/ws2811.c',
             './src/rpi_ws281x/pwm.c',
             './src/rpi_ws281x/dma.c',
+            './src/rpi_ws281x/pcm.c',
+            './src/rpi_ws281x/pwm.c',
             './src/rpi_ws281x/mailbox.c',
-            './src/rpi_ws281x/board_info.c'
+            './src/rpi_ws281x/rpihw.c'
           ],
           'cflags': ['-O2', '-Wall']
         },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "bugs": "https://github.com/beyondscreen/node-rpi-ws281x-native/issues",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.0.9"
+    "node-addon-api": "^3.0.0"
   },
   "devDependencies": {}
 }

--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -1,177 +1,158 @@
-#include <nan.h>
-
-#include <v8.h>
-
 #include <stdio.h>
-#include <stdint.h>
-#include <string.h>
 
-#include <algorithm>
+#include "napi.h"
 
 extern "C" {
   #include "rpi_ws281x/ws2811.h"
 }
-
-using namespace v8;
 
 #define DEFAULT_TARGET_FREQ     800000
 #define DEFAULT_GPIO_PIN        18
 #define DEFAULT_DMANUM          5
 
 ws2811_t ledstring;
-ws2811_channel_t
-  channel0data,
-  channel1data;
+ws2811_channel_t channel0data, channel1data;
 
+Napi::Value init(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
 
-/**
- * exports.render(Uint32Array data) - sends the data to the LED-strip,
- *   if data is longer than the number of leds, remaining data will be ignored.
- *   Otherwise, data
- */
-void render(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  if(info.Length() != 1) {
-    Nan::ThrowTypeError("render(): missing argument.");
-    return;
-  }
-
-  if(!node::Buffer::HasInstance(info[0])) {
-    Nan::ThrowTypeError("render(): expected argument to be a Buffer.");
-    return;
-  }
-
-  Local<Object> buffer = info[0]->ToObject();
-
-  int numBytes = std::min((int)node::Buffer::Length(buffer),
-      4 * ledstring.channel[0].count);
-
-  uint32_t* data = (uint32_t*) node::Buffer::Data(buffer);
-  memcpy(ledstring.channel[0].leds, data, numBytes);
-
-  ws2811_wait(&ledstring);
-  ws2811_render(&ledstring);
-
-  info.GetReturnValue().SetUndefined();
-}
-
-
-/**
- * exports.init(Number ledCount [, Object config]) - setup the configuration and initialize the library.
- */
-void init(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  ledstring.freq    = DEFAULT_TARGET_FREQ;
-  ledstring.dmanum  = DEFAULT_DMANUM;
-
-  channel0data.gpionum = DEFAULT_GPIO_PIN;
-  channel0data.invert = 0;
-  channel0data.count = 0;
-  channel0data.brightness = 255;
-
-  channel1data.gpionum = 0;
-  channel1data.invert = 0;
-  channel1data.count = 0;
-  channel1data.brightness = 255;
-
-  ledstring.channel[0] = channel0data;
-  ledstring.channel[1] = channel1data;
-
-  if(info.Length() < 1) {
-    return Nan::ThrowTypeError("init(): expected at least 1 argument");
-  }
-
-  // first argument is a number
-  if(!info[0]->IsNumber()) {
-    return Nan::ThrowTypeError("init(): argument 0 is not a number");
-  }
-
-  ledstring.channel[0].count = info[0]->Int32Value();
-
-  // second (optional) an Object
-  if(info.Length() >= 2 && info[1]->IsObject()) {
-    Local<Object> config = info[1]->ToObject();
-
-    Local<String>
-        symFreq = Nan::New<String>("frequency").ToLocalChecked(),
-        symDmaNum = Nan::New<String>("dmaNum").ToLocalChecked(),
-        symGpioPin = Nan::New<String>("gpioPin").ToLocalChecked(),
-        symInvert = Nan::New<String>("invert").ToLocalChecked(),
-        symBrightness = Nan::New<String>("brightness").ToLocalChecked();
-
-    if(Nan::HasOwnProperty(config, symFreq).FromMaybe(false)) {
-      ledstring.freq = config->Get(symFreq)->Uint32Value();
+    if (info.Length() != 1 && info.Length() != 2) {
+        std::string err = "Wrong number of arguments " + info.Length();
+        Napi::TypeError::New(env, err.c_str()).ThrowAsJavaScriptException();
+        return env.Null();
     }
 
-    if(Nan::HasOwnProperty(config, symDmaNum).FromMaybe(false)) {
-      ledstring.dmanum = config->Get(symDmaNum)->Int32Value();
+    if (!info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Wrong type number of leds").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+    int32_t count = info[0].As<Napi::Number>().Int32Value();
+
+    // second (optional) an Object
+    if (info.Length() == 2 && info[1].IsObject()) {
+        Napi::Object config = info[1].As<Napi::Object>();
+
+        if (config.Has("frequency")) {
+            ledstring.freq = config.Get("frequency").As<Napi::Number>().Int32Value();
+        }
+
+        if (config.Has("dmaNum")) {
+            ledstring.dmanum = config.Get("dmaNum").As<Napi::Number>().Int32Value();
+        }
+
+        if (config.Has("gpioPin")) {
+            ledstring.channel[0].gpionum = config.Get("gpioPin").As<Napi::Number>().Int32Value();
+        }
+
+        if (config.Has("invert")) {
+            ledstring.channel[0].invert = config.Get("invert").As<Napi::Number>().Int32Value();
+        }
+
+        if (config.Has("brightness")) {
+            ledstring.channel[0].brightness = config.Get("brightness").As<Napi::Number>().Int32Value();
+        }
     }
 
-    if(Nan::HasOwnProperty(config, symGpioPin).FromMaybe(false)) {
-      ledstring.channel[0].gpionum = config->Get(symGpioPin)->Int32Value();
+    ledstring.freq = DEFAULT_TARGET_FREQ;
+    ledstring.dmanum  = DEFAULT_DMANUM;
+
+    channel0data.gpionum = DEFAULT_GPIO_PIN;
+    channel0data.invert = 0;
+    channel0data.count = 0;
+    channel0data.brightness = 255;
+
+    channel1data.gpionum = 0;
+    channel1data.invert = 0;
+    channel1data.count = 0;
+    channel1data.brightness = 255;
+
+    ledstring.channel[0] = channel0data;
+    ledstring.channel[1] = channel1data;
+
+    ledstring.channel[0].count = count;
+
+    ws2811_return_t err = ws2811_init(&ledstring);
+
+    if (err) {
+        printf("error initializing %i %s\n", err, ws2811_get_return_t_str(err));
+        Napi::TypeError::New(env, "Init Error").ThrowAsJavaScriptException();
     }
 
-    if(Nan::HasOwnProperty(config, symInvert).FromMaybe(false)) {
-      ledstring.channel[0].invert = config->Get(symInvert)->Int32Value();
+    return env.Null();
+}
+
+Napi::Value setBrightness(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
+
+    if (info.Length() != 1) {
+        std::string err = "Wrong number of arguments " + info.Length();
+        Napi::TypeError::New(env, err.c_str()).ThrowAsJavaScriptException();
+        return env.Null();
     }
 
-    if(Nan::HasOwnProperty(config, symBrightness).FromMaybe(false)) {
-      ledstring.channel[0].brightness = config->Get(symBrightness)->Int32Value();
+    if (!info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Wrong type argument 0").ThrowAsJavaScriptException();
+        return env.Null();
     }
-  }
+    int32_t brightness = info[0].As<Napi::Number>().Int32Value();
 
-  // FIXME: handle errors, throw JS-Exception
-  int err = ws2811_init(&ledstring);
+    ledstring.channel[0].brightness = brightness;
 
-  if(err) {
-      return Nan::ThrowError("init(): initialization failed. sorry – no idea why.");
-  }
-  info.GetReturnValue().SetUndefined();
+    return env.Null();
 }
 
+Napi::Value reset(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
 
-/**
- * exports.setBrightness()
- */
-void setBrightness(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  if(info.Length() != 1) {
-      return Nan::ThrowError("setBrightness(): no value given");
-  }
+    memset(ledstring.channel[0].leds, 0, sizeof(*ledstring.channel[0].leds) * ledstring.channel[0].count);
 
-  // first argument is a number
-  if(!info[0]->IsNumber()) {
-    return Nan::ThrowTypeError("setBrightness(): argument 0 is not a number");
-  }
+    ws2811_render(&ledstring);
+    ws2811_wait(&ledstring);
+    ws2811_fini(&ledstring);
 
-  ledstring.channel[0].brightness = info[0]->Int32Value();
-
-  info.GetReturnValue().SetUndefined();
+    return env.Null();
 }
 
+Napi::Value render(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    Napi::HandleScope scope(env);
 
-/**
- * exports.reset() – blacks out the LED-strip and finalizes the library
- * (disable PWM, free DMA-pages etc).
- */
-void reset(const Nan::FunctionCallbackInfo<v8::Value>& info) {
-  memset(ledstring.channel[0].leds, 0, sizeof(*ledstring.channel[0].leds) * ledstring.channel[0].count);
+    if (info.Length() != 1) {
+        std::string err = "Wrong number of arguments " + info.Length();
+        Napi::TypeError::New(env, err.c_str()).ThrowAsJavaScriptException();
+        return env.Null();
+    }
 
-  ws2811_render(&ledstring);
-  ws2811_wait(&ledstring);
-  ws2811_fini(&ledstring);
+    if (!info[0].IsTypedArray()) {
+        Napi::TypeError::New(env, "Wrong type argument 0").ThrowAsJavaScriptException();
+        return env.Null();
+    }
 
-  info.GetReturnValue().SetUndefined();
+    Napi::Uint32Array values = info[0].As<Napi::Uint32Array>();
+
+    if (values.ByteLength() < sizeof(*ledstring.channel[0].leds) * ledstring.channel[0].count) {
+        Napi::TypeError::New(env, "Wrong length").ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    memcpy(ledstring.channel[0].leds, values.Data(), sizeof(*ledstring.channel[0].leds) * ledstring.channel[0].count);
+
+    ws2811_wait(&ledstring);
+    ws2811_render(&ledstring);
+
+    return env.Null();
 }
 
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set(Napi::String::New(env, "init"), Napi::Function::New(env, init));
+    exports.Set(Napi::String::New(env, "setBrightness"), Napi::Function::New(env, setBrightness));
+    exports.Set(Napi::String::New(env, "reset"), Napi::Function::New(env, reset));
+    exports.Set(Napi::String::New(env, "render"), Napi::Function::New(env, render));
 
-/**
- * initializes the module.
- */
-void initialize(Handle<Object> exports) {
-  NAN_EXPORT(exports, init);
-  NAN_EXPORT(exports, reset);
-  NAN_EXPORT(exports, render);
-  NAN_EXPORT(exports, setBrightness);
+    return exports;
 }
 
-NODE_MODULE(rpi_ws281x, initialize)
-
-// vi: ts=2 sw=2 expandtab
+NODE_API_MODULE(wrapper, Init)


### PR DESCRIPTION
- NAPI gives long-term support
- old code had tight v8 dependencies that do not work with node 12 and later
- also changed to use a newer version of the native code that has better error codes