### PR TITLE
added bcm2711 to work on raspberry pi 4

### DIFF
--- a/lib/ws281x-native.js
+++ b/lib/ws281x-native.js
@@ -44,6 +44,7 @@ function getNativeBindings() {
             case 'bcm2708': return 1;
             case 'bcm2835': return 1;
             case 'bcm2709': return 2;
+            case 'bcm2711': return 1;
             default: return 0;
         }
     } ());


### PR DESCRIPTION
This feature works on the raspberry pi 4, without it the leds not turning on