### PR TITLE
Changed default DMA to 10

### DIFF
--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -8,7 +8,7 @@ extern "C" {
 
 #define DEFAULT_TARGET_FREQ     800000
 #define DEFAULT_GPIO_PIN        18
-#define DEFAULT_DMANUM          5
+#define DEFAULT_DMANUM          10
 
 ws2811_t ledstring;
 ws2811_channel_t channel0data, channel1data;


### PR DESCRIPTION
The used library project - https://github.com/jgarff/rpi_ws281x - now has a big warning about using DMA channel 5. Apparently on more recent Raspi versions this is used by the file system, leading to corruption.