### PR TITLE
added support for option 'strip_type'

### DIFF
--- a/src/rpi-ws281x.cc
+++ b/src/rpi-ws281x.cc
@@ -69,6 +69,10 @@ Napi::Value init(const Napi::CallbackInfo& info) {
         if (config.Has("brightness")) {
             ledstring.channel[0].brightness = config.Get("brightness").As<Napi::Number>().Int32Value();
         }
+
+        if (config.Has("strip_type")) {
+            ledstring.channel[0].strip_type = config.Get("strip_type").As<Napi::Number>().Int32Value();
+        }
     }
 
     ws2811_return_t err = ws2811_init(&ledstring);


### PR DESCRIPTION
See [ws2811.h](https://github.com/jgarff/rpi_ws281x/blob/master/ws2811.h) for the respective constants, e.g. "WS2811_STRIP_RGB = 0x00100800"
Basically it's the shift-pattern to get 3 (or 4) consecutive bytes from the 32bit color value.
The default value in [ws2811.c](https://github.com/jgarff/rpi_ws281x/blob/master/ws2811.c) is WS2811_STRIP_RGB