### PR TITLE
Fix typo in README examplle

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ way for initialization using the top-level export function.
 #### Example:
 
 ```javascript
-const ws2821x = require('rpi-ws281x-native');
+const ws281x = require('rpi-ws281x-native');
 const options = {
   dma: 10,
   freq: 800000,
@@ -95,7 +95,7 @@ Configures and initializes the drivers and returns an array of channel-interface
 #### Example:
 
 ```javascript
-const ws2821x = require('rpi-ws281x-native');
+const ws281x = require('rpi-ws281x-native');
 
 const channels = ws281x.init({
   dma: 10,
@@ -130,7 +130,7 @@ Send the current state of the channel color-buffers to the LEDs.
 #### Example:
 
 ```javascript
-const ws2821x = require('rpi-ws281x-native');
+const ws281x = require('rpi-ws281x-native');
 
 // initialize
 const [channel] = ws281x.init(options);


### PR DESCRIPTION
👋 Hey friends! I found a small typo when I was setting up this on my pi zero & copy/pasting the examples (since I needed to change the GPIO pin). Just wanted to fix it in case others do the same.